### PR TITLE
Fixed README instructions on running tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Requirements
 
 Run the following to get pyxb and nosetests:
 - pip install pyxb
-- pip install nosetests
+- pip install nose
 - pip install Magicmock
+- pip install unittest2
+- pip install lxml
 
 Testing
 --------------------------------------


### PR DESCRIPTION
There is no such pip installable library 'nosesests' and a couple required libraries were missing from the instructions.