### PR TITLE
- Fix for issue #65 and #73.

### DIFF
--- a/tests/testpyxb.py
+++ b/tests/testpyxb.py
@@ -171,7 +171,7 @@ class test_CustomerProfile(unittest.TestCase):
             
             logging.error( 'Create Document Exception: %s, %s', type(ex), ex.args )
         
-        self.assertEquals(type(getCustomerProfileRequest), type(deserializedObject), "deseriaziedObject does not match original object")
+        self.assertEqual(type(getCustomerProfileRequest), type(deserializedObject), "deseriaziedObject does not match original object")
         
         try:
             #print("starting with element in mid")


### PR DESCRIPTION
- In apicontrollersbase.py, when an exception occured, another exception was thrown while trying to call CreateFromDocument function. Due to this, the xmlResponse to lxml object conversion did not happen correctly and hence the API errors were not deserialized correctly.
- Also, for issue #73, added utf-8 encode and decode methods, so that response can be logged correctly.