### PR TITLE
update config for CI tests to pass again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,50 @@
 language: python
+
 sudo: false
 
+env:
+  - TEST_SUITE=samples
+  - TEST_SUITE=coverage
 python:
   - "2.7"
   - "3.4"
   - "3.5"
-  # - "pypy" Disabling pypy until travis moves to newer version, known issue with lxml crashing pypy
+  - "3.6"
+  - "3.7-dev"
+  - "pypy"
+  - "pypy3"
+  
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: "3.7-dev"
+      # 3.7-dev started crashing when building lxml although the neither the python version nor the lxml version seemed to change.
+      # Will have to investigate further.
+    - python: "pypy"
+    - python: "pypy3"
+      # pypy will just crash due to an incompatibility with lxml.
+      # Newer versions of pypy seem to crash also, so we probably have to fix with a newer version of lxml
+
+before_install:
+  # execute all of the commands which need to be executed 
+  # before installing dependencies
   
 install:
- - pip install unittest2
- - pip install nose
- - pip install pyxb
- - pip install lxml
- - pip install coveralls
+  # install all of the dependencies we need here
+  - pip install nose
+  - pip install pyxb==1.2.5
+    # can't change the pyxb version without changing the version in setup.py
+    # and regenerating the bindings in apicontractsv1.py
+  - pip install lxml
+  - if [[ "$TEST_SUITE" == "coverage" ]]; then pip install coveralls; fi
 
 before_script:
-  - git submodule update --remote --recursive
+  # execute all of the commands which need to be executed 
+  # before running actual tests
+  - if [[ "$TEST_SUITE" == "samples" ]]; then git submodule update --remote --recursive; fi
 
 script:
- - nosetests --with-coverage -cover-package=authorizenet
- - coveralls
- - python setup.py install
- - cd sample-code-python
- - python ./test-runner.py
+  # execute all of the tests or other commands to determine
+  # whether the build will pass or fail
+  - if [[ "$TEST_SUITE" == "coverage" ]]; then nosetests --with-coverage -cover-package=authorizenet; coveralls; fi
+  - if [[ "$TEST_SUITE" == "samples" ]]; then python setup.py install; cd sample-code-python; python ./test-runner.py; fi

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ The API Reference Guide provides examples of what information is needed for a pa
 
 Run the following to get pyxb and nosetests:
 - pip install pyxb==1.2.5
-- pip install unittest2
 - pip install nose
 - pip install lxml
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4'
     ],
 
     # What does your project relate to?
@@ -63,11 +64,11 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['pyxb==1.2.5', 'nose', 'mock', 'lxml'],
-	#install_requires=['nose'],
-	#install_requires=['nosetests'],
-	#install_requires=['mock'],
-	#install_requires=['lxml'],
-	
+    #install_requires=['nose'],
+    #install_requires=['nosetests'],
+    #install_requires=['mock'],
+    #install_requires=['lxml'],
+
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:
@@ -80,22 +81,22 @@ setup(
     },
     environment_variables={
         #api.login.id : xyz
-        #transaction.key : xyz 
+        #transaction.key : xyz
         #md5.hash.key : MD5_HASH_KEY
     },
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
-	#package_data={
+    #package_data={
     #    'sample': ['package_data.dat'],
-    #}, 
-	
+    #},
+
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-	# data_files=[('my_data', ['data/data_file'])],
+    # data_files=[('my_data', ['data/data_file'])],
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
@@ -104,5 +105,5 @@ setup(
     #    'console_scripts': [
     #        'sample=sample:main',
     #    ],
-    #}, 
+    #},
 )


### PR DESCRIPTION
- hardcode required pyxb version
- change travis config to support testing against more versions, and break up tests into coverage and samples
- remove unused unittest2 dependency