### PR TITLE
Removes reference to private field in pip

### DIFF
--- a/authorizenet/apicontrollersbase.py
+++ b/authorizenet/apicontrollersbase.py
@@ -8,7 +8,7 @@ import logging
 import pyxb
 import sys
 import xml.dom.minidom
-from pip._vendor import requests
+import requests
 from lxml import objectify
 
 from authorizenet.constants import constants


### PR DESCRIPTION
pip._vendor is failing when using this library. The accepted solution in other projects with similar issues is to remove `pip._vendor` and simply `import requests`. 