### PR TITLE
Fix setup.cfg description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = DESCRIPTION.rst
+description_file = DESCRIPTION.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = DESCRIPTION.rst

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,10 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 
+with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
 setup(
     name='authorizenet',
 
@@ -20,6 +24,7 @@ setup(
     version='1.1.5',
 
     description='Authorize.Net Python SDK',
+    long_description=long_description,
 
     # The project's main homepage.
     url='https://github.com/AuthorizeNet/sdk-python',


### PR DESCRIPTION
`setup.cfg` is using a long-deprecated field name, which now does not build with the latest version of `setuptools`. This PR updates the field name to its currently-supported equivalent:

```
Collecting authorizenet==1.1.5 (from -r requirements.txt (line 7))
  Downloading authorizenet-1.1.5.tar.gz (158 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [31 lines of output]
      Traceback (most recent call last):
        File "/usr/app/venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/usr/app/venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/app/venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 14, in <module>
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 116, in setup
          _install_setup_requires(attrs)
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 87, in _install_setup_requires
          dist.parse_config_files(ignore_option_errors=True)
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 730, in parse_config_files
          self._parse_config_files(filenames=inifiles)
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 599, in _parse_config_files
          opt = self._enforce_underscore(opt, section)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-scnu31m8/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 629, in _enforce_underscore
          raise InvalidConfigError(
      setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```

Closes #166 